### PR TITLE
타입스크립트와의 호환성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@babel/core": "^7.19.6",
         "@babel/preset-env": "^7.19.4",
         "@rollup/plugin-babel": "^6.0.2",
+        "@rollup/plugin-node-resolve": "^15.0.1",
         "babel-jest": "^29.2.2",
         "jest": "^29.2.2",
         "rollup": "^3.2.3",
@@ -2403,6 +2404,31 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
+      "integrity": "sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
@@ -2539,6 +2565,12 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+      "dev": true
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -2890,6 +2922,18 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -3447,6 +3491,21 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
+      "integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
@@ -3476,6 +3535,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -7951,6 +8016,20 @@
         "@rollup/pluginutils": "^5.0.1"
       }
     },
+    "@rollup/plugin-node-resolve": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
+      "integrity": "sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      }
+    },
     "@rollup/pluginutils": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
@@ -8076,6 +8155,12 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+      "dev": true
+    },
+    "@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -8343,6 +8428,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true
     },
     "callsites": {
@@ -8756,6 +8847,15 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
+    "is-builtin-module": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
+      "integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.3.0"
+      }
+    },
     "is-core-module": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
@@ -8775,6 +8875,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "dev": true
     },
     "is-number": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,23 @@
 {
   "name": "mockpress",
-  "version": "0.1.9",
+  "version": "0.2.2",
   "description": "Mock data generator, simple and flexible.",
   "sideEffects": false,
+  "files": [
+    "dist"
+  ],
   "type": "module",
+  "types": "dist/index.d.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
-      "require": "./dist/cjs/bundle.cjs",
-      "import": "./dist/esm/index.js"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.esm.mjs",
+      "require": "./dist/index.cjs.js"
     }
   },
-  "main": "./dist/cjs/bundle.cjs",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.mjs",
   "scripts": {
     "build": "rm -rf dist && rollup -c rollup.config.js",
     "prepublishOnly": "npm run build && npm run type",
@@ -28,6 +35,7 @@
     "@babel/core": "^7.19.6",
     "@babel/preset-env": "^7.19.4",
     "@rollup/plugin-babel": "^6.0.2",
+    "@rollup/plugin-node-resolve": "^15.0.1",
     "babel-jest": "^29.2.2",
     "jest": "^29.2.2",
     "rollup": "^3.2.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import { nodeResolve } from "@rollup/plugin-node-resolve";
 import { getBabelOutputPlugin } from "@rollup/plugin-babel";
 
 export default [
@@ -7,16 +8,16 @@ export default [
       getBabelOutputPlugin({
         presets: ["@babel/preset-env"],
       }),
+      nodeResolve(),
     ],
     external: ["nanoid"],
     output: [
       {
-        dir: "./dist/esm",
+        file: "./dist/index.esm.mjs",
         format: "es",
-        preserveModules: true,
       },
       {
-        file: "./dist/cjs/bundle.cjs",
+        file: "./dist/index.cjs.js",
         format: "cjs",
       },
     ],

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,4 +1,4 @@
-import * as util from "./utils/index";
+import * as util from "./utils";
 
 // @TODO: 코드를 조금 더 단순하게 작성한다
 const resolve = (schema, loopIndex, getterSchemaObj, currentKey) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-export * as util from "./utils/index";
-export * as mock from "./mocks/index";
+export * as util from "./utils";
+export * as mock from "./mocks";
 export { default as generate } from "./generator";

--- a/src/mocks/autoIncrement.js
+++ b/src/mocks/autoIncrement.js
@@ -2,7 +2,7 @@
  * Generates an auto incremented index, based on the loopIndex of the generator.
  *
  * @param { number } [startPoint] Starting point of autoIncrement number. Defaults to 0.
- * @returns { number } Auto-incremented number (+ 1 from previous data).
+ * @returns { function(any, number): number } Auto-incremented number (+ 1 from previous data).
  */
 const autoIncrement =
   (startPoint = 0) =>

--- a/src/mocks/date.js
+++ b/src/mocks/date.js
@@ -1,4 +1,4 @@
-import * as util from "../utils/index";
+import * as util from "../utils";
 
 //@TODO: 더 쉬운 날짜 범위 지정 방식이 필요할듯 싶다
 

--- a/src/mocks/date.js
+++ b/src/mocks/date.js
@@ -7,7 +7,7 @@ import * as util from "../utils";
  *
  * @param { Date } startDate Generated date would be after the given date.
  * @param { Date } endDate Generated date would be before the given date.
- * @returns { Date } Generated Date object.
+ * @returns { function(any, number): Date } Generated Date object.
  */
 const date = (startDate, endDate) => (_, loopIndex) => {
   return util.randomDate(startDate, endDate);

--- a/src/mocks/image.js
+++ b/src/mocks/image.js
@@ -1,4 +1,4 @@
-import * as util from "../utils/index";
+import * as util from "../utils";
 
 /**
  * Generates a random Image of the given size.

--- a/src/mocks/image.js
+++ b/src/mocks/image.js
@@ -6,7 +6,7 @@ import * as util from "../utils";
  *
  * @param { number } [width] Width of the generated image in px. Defaults to 300.
  * @param { number } [height] Height of the generated image in px. Defaults to 300.
- * @returns { string } Url of the random image.
+ * @returns { function(any, number): string } Url of the random image.
  */
 const image =
   (width = 300, height = 300) =>

--- a/src/mocks/index.js
+++ b/src/mocks/index.js
@@ -1,9 +1,9 @@
-export { default as autoIncrement } from "./autoIncrement.js";
-export { default as date } from "./date.js";
-export { default as image } from "./image.js";
-export { default as integer } from "./integer.js";
-export { default as koreanAddress } from "./koreanAddress.js";
-export { default as koreanName } from "./koreanName.js";
-export { default as money } from "./money.js";
+export { default as autoIncrement } from "./autoIncrement";
+export { default as date } from "./date";
+export { default as image } from "./image";
+export { default as integer } from "./integer";
+export { default as koreanAddress } from "./koreanAddress";
+export { default as koreanName } from "./koreanName";
+export { default as money } from "./money";
 export { default as koreanWord } from "./koreanWord";
 export { default as koreanSentence } from "./koreanSentence";

--- a/src/mocks/integer.js
+++ b/src/mocks/integer.js
@@ -1,4 +1,4 @@
-import * as util from "../utils/index";
+import * as util from "../utils";
 
 /**
  * Generates a random integer in the given range.

--- a/src/mocks/integer.js
+++ b/src/mocks/integer.js
@@ -5,7 +5,7 @@ import * as util from "../utils";
  *
  * @param { number } [min] Minimum for the generated number. Defaults to 0.
  * @param { number } [max] Maximum for the generated number. Defaults to 1000.
- * @returns { number } Generated number.
+ * @returns { function(any, number): number } Generated number.
  */
 const integer =
   (min = 0, max = 1000) =>

--- a/src/mocks/koreanAddress.js
+++ b/src/mocks/koreanAddress.js
@@ -6,7 +6,7 @@ import * as util from "../utils";
  * Generated address follow the basic rules of the South Korean address system.
  * However, generated addresses are fake and do not exist in the real world.
  *
- * @returns { string } A random virtual korean address.
+ * @returns { function(any, number): string } A random virtual korean address.
  */
 const koreanAddress = () => (_, loopIndex) => {
   return util.randomKoreanAddress();

--- a/src/mocks/koreanAddress.js
+++ b/src/mocks/koreanAddress.js
@@ -1,4 +1,4 @@
-import * as util from "../utils/index";
+import * as util from "../utils";
 
 // @TODO: location을 받아서 여러 나라를 지원하자
 /**

--- a/src/mocks/koreanName.js
+++ b/src/mocks/koreanName.js
@@ -1,4 +1,4 @@
-import * as util from "../utils/index";
+import * as util from "../utils";
 
 /**
  * Generates a random Korean name.

--- a/src/mocks/koreanName.js
+++ b/src/mocks/koreanName.js
@@ -5,7 +5,7 @@ import * as util from "../utils";
  * The options consist of popular male and female baby names between 2008-2021.
  *
  * @param { 'male' | 'female' } [gender] The gender for the generated name.
- * @returns A Korean name of the given gender. If none given, the gender is also random.
+ * @returns { function(any, number): string } A Korean name of the given gender. If none given, the gender is also random.
  */
 const koreanName = (gender) => (_, loopIndex) => {
   return util.randomKoreanName(gender);

--- a/src/mocks/koreanSentence.js
+++ b/src/mocks/koreanSentence.js
@@ -3,7 +3,7 @@ import * as util from "../utils";
 /**
  * Generate a random korean sentence
  * @param { undefined | 'short' | 'medium' | 'long' } Size of generated sentence.
- * @returns { string } Generated sentence of a given size.
+ * @returns { function(any, number): string } Generated sentence of a given size.
  */
 const koreanSentence = (size) => (_, loopIndex) => {
   return util.randomKoreanSentence(size);

--- a/src/mocks/koreanSentence.js
+++ b/src/mocks/koreanSentence.js
@@ -1,4 +1,4 @@
-import * as util from "../utils/index";
+import * as util from "../utils";
 
 /**
  * Generate a random korean sentence

--- a/src/mocks/koreanWord.js
+++ b/src/mocks/koreanWord.js
@@ -1,4 +1,4 @@
-import * as util from "../utils/index";
+import * as util from "../utils";
 
 /**
  * Generates a random korean word

--- a/src/mocks/koreanWord.js
+++ b/src/mocks/koreanWord.js
@@ -3,7 +3,7 @@ import * as util from "../utils";
 /**
  * Generates a random korean word
  *
- * @returns Random word
+ * @returns { function(any, number): string } Random word
  */
 const koreanWord = () => (_, loopIndex) => {
   return util.randomKoreanWord();

--- a/src/mocks/money.js
+++ b/src/mocks/money.js
@@ -1,4 +1,4 @@
-import * as util from "../utils/index";
+import * as util from "../utils";
 
 /**
  * Generates a random amount of money in the given range.

--- a/src/mocks/money.js
+++ b/src/mocks/money.js
@@ -6,7 +6,7 @@ import * as util from "../utils";
  * @param { number } [min] Minimum amount of money. Defaults to 100.
  * @param { number } [max] Maximum amount of money. Defaults to 10000.
  * @param { number } [interval] Refers to the minimum unit of money. Defaults to 1000.
- * @returns { number } Random amount of money.
+ * @returns { function(any, number): number } Random amount of money.
  */
 const money =
   (min = 100, max = 10000, interval = 1000) =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     // Types should go into this directory.
     // Removing this would place the .d.ts files
     // next to the .js files
-    "outDir": "types",
+    "outDir": "dist",
     // go to js file when using IDE functions like
     // "Go to Definition" in VSCode
     "declarationMap": true


### PR DESCRIPTION
타입스크립트와 호환이 되지 않고 있었습니다.  

그래서 아래와 같은 수정을 했습니다.

1. react-hook-form을 참고하여 package.json 부분에 'types' 부분을 추가했습니다
2. rollup에 node-resolve를 적용하서 file extension 없이도 import 되도록 설정했습니다
3. jsdoc에서 함수의 return type을 수정했습니다. `(current: any, loopIndex: number): number` 이런식의 return type이 나오도록 수정했습니다.