### PR TITLE
current 객체 오류 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockpress",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "Mock data generator, simple and flexible.",
   "sideEffects": false,
   "files": [

--- a/sample.js
+++ b/sample.js
@@ -3,14 +3,12 @@ import { mock, generate } from "./src/index.js";
 const result = generate(
   {
     id: mock.autoIncrement(),
-    name: mock.koreanName(),
     introduce: (current, loopIndex) => {
-      return `Hello, my name is ${current.name}`;
+      return `Hello, my name is ${current.hobby.introduce}`;
     },
     hobby: {
-      cost: mock.money(1000, 20000, 1000),
       introduce: (current, loopIndex) => {
-        return `This hobby's cost is ${current.hobby.cost}`;
+        return `This hobby's cost is ${current.introduce}`;
       },
     },
   },

--- a/sample.js
+++ b/sample.js
@@ -1,26 +1,20 @@
 import { mock, generate } from "./src/index.js";
 
-const personSchema = {
-  id: mock.autoIncrement(),
-  index: (current, loopIndex) => `${loopIndex + 1} 번째 Object`,
-  name: mock.koreanName(),
-  introduce: (current, loopIndex) =>
-    `안녕하세요 제 이름은 ${current.name} 입니다!`,
-  parents: {
-    mother: {
-      name: mock.koreanName(),
+const result = generate(
+  {
+    id: mock.autoIncrement(),
+    name: mock.koreanName(),
+    introduce: (current, loopIndex) => {
+      return `Hello, my name is ${current.name}`;
+    },
+    hobby: {
+      cost: mock.money(1000, 20000, 1000),
+      introduce: (current, loopIndex) => {
+        return `This hobby's cost is ${current.hobby.cost}`;
+      },
     },
   },
-  parentIntroduce: (current, loopIndex) =>
-    `저희 어머니 성함은 ${current.parents.mother.name} 입니다!`,
-  profileImage: mock.image(200, 200),
-  age: mock.integer(10, 20),
-  address: mock.koreanAddress(),
-  hobby: {
-    id: mock.autoIncrement(),
-    cost: mock.money(1000, 10000, 100),
-  },
-};
+  2
+);
 
-const result = generate(personSchema, 2);
 console.dir(result, { depth: null });

--- a/src/example.js
+++ b/src/example.js
@@ -19,6 +19,9 @@ const personSchema = {
     id: mock.autoIncrement(),
     name: mock.koreanWord(),
     cost: mock.money(1000, 10000, 100),
+    introduce: (current, loopIndex) => {
+      return `This hobby's cost is ${current.hobby.cost}`;
+    },
   },
 };
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,43 +1,50 @@
 import * as util from "./utils";
 
-// @TODO: 코드를 조금 더 단순하게 작성한다
-const resolve = (schema, loopIndex, getterSchemaObj, currentKey) => {
-  return util.isFunction(schema[currentKey])
-    ? schema[currentKey](getterSchemaObj, loopIndex)
-    : util.isPlainObject(schema[currentKey])
-    ? generateOnce(schema[currentKey], loopIndex, getterSchemaObj)
-    : schema[currentKey];
-};
+const cachePlaceholder = Symbol("cachePlaceholder");
 
-function generateOnce(schema, loopIndex, outerGetterSchemaObj) {
-  const result = {};
+function generateOnce(schema, loopIndex, result, getterObj) {
   const keys = Object.keys(schema);
-  const callHistory = {};
-  const getterSchemaObj =
-    outerGetterSchemaObj ??
-    keys.reduce((acc, cur) => {
-      Object.defineProperty(acc, cur, {
-        get: () => {
-          if (result[cur]) {
-            return result[cur];
-          }
-          if (callHistory[cur]) {
-            throw new Error(`${cur}에 순환 참조가 있습니다`);
-          }
-          callHistory[cur] = true;
-          result[cur] = resolve(schema, loopIndex, getterSchemaObj, cur);
-          return result;
-        },
-      });
-      return acc;
-    }, {});
-
   for (let i = 0; i < keys.length; i += 1) {
     const key = keys[i];
-    result[key] = resolve(schema, loopIndex, getterSchemaObj, key);
+    const val = schema[key];
+    if (util.isPlainObject(val)) {
+      result[key] = generateOnce(val, loopIndex, {}, getterObj[key]);
+    } else {
+      result[key] = getterObj[key];
+    }
   }
-
   return result;
+}
+
+function schemaToGetterObj(schema, loopIndex, getterObj, globalGetterObj) {
+  const keys = Object.keys(schema);
+  for (let i = 0; i < keys.length; i += 1) {
+    const key = keys[i];
+    const val = schema[key];
+    if (util.isPlainObject(val)) {
+      const newGetterObj = {};
+      getterObj[key] = newGetterObj;
+      schemaToGetterObj(val, loopIndex, newGetterObj, globalGetterObj);
+    } else if (util.isFunction(val)) {
+      let cache = cachePlaceholder;
+      let isCalled = false;
+
+      Object.defineProperty(getterObj, key, {
+        get: () => {
+          if (cache !== cachePlaceholder) {
+            return cache;
+          }
+          if (cache === null && isCalled) {
+            throw new Error(`${key}에 순환 참조가 있습니다`);
+          }
+          cache = val(globalGetterObj, loopIndex);
+          return cache;
+        },
+      });
+    } else {
+      getterObj[key] = val;
+    }
+  }
 }
 
 /**
@@ -50,7 +57,10 @@ function generateOnce(schema, loopIndex, outerGetterSchemaObj) {
 function generate(schema, count = 10) {
   const resultArr = [];
   for (let i = 0; i < count; i += 1) {
-    const result = generateOnce(schema, i);
+    const getterObj = {};
+    schemaToGetterObj(schema, i, getterObj, getterObj);
+
+    const result = generateOnce(schema, i, {}, getterObj);
     resultArr.push(result);
   }
   return resultArr;

--- a/src/generator.js
+++ b/src/generator.js
@@ -34,9 +34,11 @@ function schemaToGetterObj(schema, loopIndex, getterObj, globalGetterObj) {
           if (cache !== cachePlaceholder) {
             return cache;
           }
-          if (cache === null && isCalled) {
+          if (cache === cachePlaceholder && isCalled) {
             throw new Error(`${key}에 순환 참조가 있습니다`);
           }
+
+          isCalled = true;
           cache = val(globalGetterObj, loopIndex);
           return cache;
         },


### PR DESCRIPTION
## 수정 내역
설명이 어려워서 예시를 먼저 보여드리겠습니다.

```javascript
generate({
  id: mock.autoIncrement(), 
  name: mock.koreanName(),
  introduce: (current, loopIndex) => {
    return `Hello, my name is ${current.name}`;
  },
  hobby: {
    cost: mock.money(1000, 20000, 1000),
    introduce: (current, loopIndex) => {
      return `This hobby's cost is ${current.hobby.cost}`
    }
  }
}, 2);
```
이전에는 inner 객체, 즉 hobby안에서 `current.hobby.cost` 이렇게 참조할 수 없었습니다.  
`current.X` 이렇게만 가능했었습니다.  
테스트 부족으로 미처 발견하지 못했던 버그였습니다.  
이번 PR에서 위 부분을 수정했습니다.  

## 코드설명
generateOnce와 schemaToGetterObj를 분리했습니다.  
핵심은 schemaToGetterObj를 통해 getterObj를 구성하고, 이후에 generateOnce에서 getterObj를 활용해 객체를 생성합니다.  
generateOnce에서 두가지 일을 하려니 코드가 너무 복잡해져서 분리했습니다.  

schemaToGetterObj에서 globalGetterObj를 받는데요, 이것은 저희가 커스텀 함수를 허용하기 때문에 넣어준것입니다.  
```javascript
introduce: (current, loopIndex) => {
    return `This hobby's cost is ${current.hobby.cost}`
}
```
여기서 current.hobby.cost 이렇게 접근할때 current는 모든걸 가지고 있는 getterObj여야 합니다. 그래서 globalGetterObj를 넣어주고, globalGetterObj에 자식-자식-자식을 계속 추가해 주는 방식으로 작동합니다.  
그리고 schema[key]가 함수일때 getter descriptor를 등록하고 여기서 globalGetterObj를 사용합니다. 

```javascript
if (util.isFunction(val)) {
  let cache = cachePlaceholder;
  let isCalled = false;

  Object.defineProperty(getterObj, key, {
    get: () => {
      if (cache !== cachePlaceholder) {
        return cache;
      }
      if (cache === cachePlaceholder && isCalled) {
        throw new Error(`${key}에 순환 참조가 있습니다`);
      }

      isCalled = true;
      cache = val(globalGetterObj, loopIndex);
      return cache;
    },
  });
}
```
 
introduce를 호출할때는 current, loopIndex를 넣어주지만, 내부에서 current.hobby.cost 이런식으로 쓸때는 호출이 아니라 그냥 '접근'만 하기 때문에 이렇게 클로저로 globalGetterObj를 잡고 있어야, cost함수에서 current를 받아 계산이 됩니다.  