### PR TITLE
boolean, age, email 필드 추가

### DIFF
--- a/src/mocks/age.ts
+++ b/src/mocks/age.ts
@@ -1,0 +1,15 @@
+import * as util from "../utils";
+
+/**
+ * Generates a random age number.
+ *
+ * @param min Minimum age.
+ * @param max Maximum age.
+ * @returns Generated age within the range.
+ */
+
+const age = (min?: number, max?: number) => {
+  return util.randomAge(min, max);
+};
+
+export default age;

--- a/src/mocks/boolean.ts
+++ b/src/mocks/boolean.ts
@@ -1,0 +1,13 @@
+import { util } from "src";
+
+/**
+ * Generates a random boolean value.
+ *
+ * @returns Generated boolean value.
+ */
+
+const boolean = () => {
+  return util.randomBoolean();
+};
+
+export default boolean;

--- a/src/mocks/boolean.ts
+++ b/src/mocks/boolean.ts
@@ -1,4 +1,4 @@
-import { util } from "src";
+import * as util from "../utils";
 
 /**
  * Generates a random boolean value.

--- a/src/mocks/email.ts
+++ b/src/mocks/email.ts
@@ -1,0 +1,13 @@
+import { randomEmail } from "../utils";
+
+/**
+ * Generates a random email address.
+ *
+ * @returns Generated email address.
+ */
+
+const email = () => {
+  return randomEmail();
+};
+
+export default email;

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,6 +1,8 @@
+export { default as age } from "./age";
 export { default as autoIncrement } from "./autoIncrement";
 export { default as boolean } from "./boolean";
 export { default as date } from "./date";
+export { default as email } from "./email";
 export { default as image } from "./image";
 export { default as integer } from "./integer";
 export { default as koreanAddress } from "./koreanAddress";

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,4 +1,5 @@
 export { default as autoIncrement } from "./autoIncrement";
+export { default as boolean } from "./boolean";
 export { default as date } from "./date";
 export { default as image } from "./image";
 export { default as integer } from "./integer";

--- a/src/test/utils/randomAge.spec.ts
+++ b/src/test/utils/randomAge.spec.ts
@@ -4,8 +4,8 @@ describe("randomAge", () => {
   it("should return a number between given range", () => {
     const min = 5;
     const max = 25;
-    const value = randomAge(min, max);
+    const age = randomAge(min, max);
 
-    expect(value >= min && max >= value);
+    expect(min <= age && age <= max);
   });
 });

--- a/src/test/utils/randomAge.spec.ts
+++ b/src/test/utils/randomAge.spec.ts
@@ -1,0 +1,11 @@
+import randomAge from "../../utils/randomAge";
+
+describe("randomAge", () => {
+  it("should return a number between given range", () => {
+    const min = 5;
+    const max = 25;
+    const value = randomAge(min, max);
+
+    expect(value >= min && max >= value);
+  });
+});

--- a/src/test/utils/randomBoolean.spec.ts
+++ b/src/test/utils/randomBoolean.spec.ts
@@ -1,0 +1,8 @@
+import randomBoolean from "../../utils/randomBoolean";
+
+describe("boolean", () => {
+  it("should return a boolean value", () => {
+    const value = randomBoolean();
+    expect(typeof value === "boolean");
+  });
+});

--- a/src/test/utils/randomEmail.spec.ts
+++ b/src/test/utils/randomEmail.spec.ts
@@ -1,0 +1,13 @@
+import randomEmail from "../../utils/randomEmail";
+
+describe("email", () => {
+  it("should generate random email address", () => {
+    const email = randomEmail();
+    const emailRegex = new RegExp(
+      /^[A-Za-z0-9_!#$%&'*+\/=?`{|}~^.-]+@[A-Za-z0-9.-]+$/,
+      "gm"
+    );
+
+    expect(emailRegex.test(email));
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { default as randomBoolean } from "./randomBoolean";
 export { default as dateToYYYYMMDD } from "./dateToYYYYMMDD";
 export { default as isFunction } from "./isFunction";
 export { default as isPlainObject } from "./isPlainObject";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { default as randomAge } from "./randomAge";
 export { default as randomBoolean } from "./randomBoolean";
 export { default as dateToYYYYMMDD } from "./dateToYYYYMMDD";
 export { default as isFunction } from "./isFunction";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,7 @@ export { default as isPlainObject } from "./isPlainObject";
 export { default as isValidDate } from "./isValidDate";
 export { default as oneOf } from "./oneOf";
 export { default as randomDate } from "./randomDate";
+export { default as randomEmail } from "./randomEmail";
 export { default as randomImage } from "./randomImage";
 export { default as randomKoreanAddress } from "./randomKoreanAddress";
 export { default as randomKoreanName } from "./randomKoreanName";

--- a/src/utils/randomAge.ts
+++ b/src/utils/randomAge.ts
@@ -1,0 +1,16 @@
+import randomNumber from "./randomNumber";
+
+const MIN = 0;
+const MAX = 150;
+
+/**
+ * Returns a random number within a given range.
+ * @param min Minimum age, defaults to 0.
+ * @param max Maximum age, defaults to 150.
+ * @returns Random age number within the given range.
+ */
+const randomAge = (min: number = MIN, max: number = MAX) => {
+  return randomNumber(min, max);
+};
+
+export default randomAge;

--- a/src/utils/randomBoolean.ts
+++ b/src/utils/randomBoolean.ts
@@ -1,0 +1,12 @@
+import randomNumber from "src/utils/randomNumber";
+
+/**
+ * Returns a random boolean.
+ *
+ * @returns Random boolean value.
+ */
+const randomBoolean = () => {
+  return randomNumber(0, 1) === 1;
+};
+
+export default randomBoolean;

--- a/src/utils/randomBoolean.ts
+++ b/src/utils/randomBoolean.ts
@@ -1,4 +1,4 @@
-import randomNumber from "src/utils/randomNumber";
+import randomNumber from "./randomNumber";
 
 /**
  * Returns a random boolean.

--- a/src/utils/randomEmail.ts
+++ b/src/utils/randomEmail.ts
@@ -1,0 +1,25 @@
+import { nanoid } from "nanoid";
+import randomNumber from "./randomNumber";
+
+const domains = [
+  "gmail.com",
+  "naver.com",
+  "hanmail.net",
+  "hotmail.com",
+  "yahoo.com",
+];
+
+/**
+ * Returns a random generated email address. User Id is totally random.
+ * Email domain is one of the following: gmail, naver, hanmail, hotmail, yahoo
+ *
+ * @returns Random email address.
+ */
+
+const randomEmail = () => {
+  const userId = nanoid(15);
+  const domain = domains[randomNumber(0, domains.length - 1)];
+  return `${userId}@${domain}`;
+};
+
+export default randomEmail;


### PR DESCRIPTION
세 가지 새로운 필드를 추가했습니다.

1. boolean
true 혹은 false를 반환합니다. 고정 값을 설정할 수 있게 만들까 고민했는데, 어차피 그냥 필드 값을 literal로 정의하면 되기 때문에 생략했습니다.

2. age
단순하게 범위 내 숫자 생성을 필드 이름으로 만든 셈입니다. 차이점이 있다면 기본적으로 나이는 0 세에서 150 세가 적당하다고 판단해서 이 범위로 기본 값을 정의했으며, 인자로 커스텀 설정할 수 있습니다.

3. email
임의의 이메일 주소를 반환합니다. user id 부분은 기존에 사용했던 nanoid 패키지를 사용해서 생성했습니다. 도메인 부분은 임시로 한국을 기준으로 자주 쓰이는 보편적인 메일 주소를 상수로 저장, 그 중에 하나를 임의로 선택하도록 구현했습니다. 현재는 사용자가 커스텀 도메인을 추가할 수 없는데, override 하거나 추가할 수 있는 방식을 생각해봐도 좋을 것 같습니다.

테스트도 모두 간단하게 작성했습니다.

closes #24 